### PR TITLE
Utility classes should not have public constructors

### DIFF
--- a/src/main/java/com/technologyconversations/java8exercises/streams/FilterCollection.java
+++ b/src/main/java/com/technologyconversations/java8exercises/streams/FilterCollection.java
@@ -7,6 +7,9 @@ import static java.util.stream.Collectors.toList;
 
 public class FilterCollection {
 
+    private FilterCollection() {
+    }
+
     public static List<String> transform7(List<String> collection) {
         List<String> newCollection = new ArrayList<>();
         for (String element : collection) {

--- a/src/main/java/com/technologyconversations/java8exercises/streams/FlatCollection.java
+++ b/src/main/java/com/technologyconversations/java8exercises/streams/FlatCollection.java
@@ -7,6 +7,9 @@ import static java.util.stream.Collectors.toList;
 
 public class FlatCollection {
 
+    private FlatCollection() {
+    }
+
     public static List<String> transform7(List<List<String>> collection) {
         List<String> newCollection = new ArrayList<>();
         for (List<String> subCollection : collection) {

--- a/src/main/java/com/technologyconversations/java8exercises/streams/Grouping.java
+++ b/src/main/java/com/technologyconversations/java8exercises/streams/Grouping.java
@@ -9,6 +9,9 @@ import static java.util.stream.Collectors.*;
 
 public class Grouping {
 
+    private Grouping() {
+    }
+
     public static Map<String, List<Person>> groupByNationality7(List<Person> people) {
         Map<String, List<Person>> map = new HashMap<>();
         for (Person person : people) {

--- a/src/main/java/com/technologyconversations/java8exercises/streams/Joining.java
+++ b/src/main/java/com/technologyconversations/java8exercises/streams/Joining.java
@@ -6,6 +6,9 @@ import static java.util.stream.Collectors.joining;
 
 public class Joining {
 
+    private Joining() {
+    }
+
     public static String namesToString7(List<Person> people) {
         String label = "Names: ";
         StringBuilder sb = new StringBuilder(label);

--- a/src/main/java/com/technologyconversations/java8exercises/streams/Partitioning.java
+++ b/src/main/java/com/technologyconversations/java8exercises/streams/Partitioning.java
@@ -5,6 +5,9 @@ import static java.util.stream.Collectors.*;
 
 public class Partitioning {
 
+    private Partitioning() {
+    }
+
     public static Map<Boolean, List<Person>> partitionAdults7(List<Person> people) {
         Map<Boolean, List<Person>> map = new HashMap<>();
         map.put(true, new ArrayList<>());

--- a/src/main/java/com/technologyconversations/java8exercises/streams/PeopleStats.java
+++ b/src/main/java/com/technologyconversations/java8exercises/streams/PeopleStats.java
@@ -5,6 +5,9 @@ import java.util.List;
 
 public class PeopleStats {
 
+    private PeopleStats() {
+    }
+
     public static Stats getStats7(List<Person> people) {
         long sum = 0;
         int min = people.get(0).getAge();

--- a/src/main/java/com/technologyconversations/java8exercises/streams/Sum.java
+++ b/src/main/java/com/technologyconversations/java8exercises/streams/Sum.java
@@ -4,6 +4,9 @@ import java.util.List;
 
 public class Sum {
 
+    private Sum() {
+    }
+
     public static int calculate7(List<Integer> numbers) {
         int total = 0;
         for (int number : numbers) {

--- a/src/main/java/com/technologyconversations/java8exercises/streams/ToUpperCase.java
+++ b/src/main/java/com/technologyconversations/java8exercises/streams/ToUpperCase.java
@@ -7,6 +7,9 @@ import static java.util.stream.Collectors.toList;
 
 public class ToUpperCase {
 
+    private ToUpperCase() {
+    }
+
     public static List<String> transform7(List<String> collection) {
         List<String> newCollection = new ArrayList<>();
         for (String element : collection) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1118 - “Utility classes should not have public constructors ”. 
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1118
Please let me know if you have any questions.
Ayman Abdelghany.
