### PR TITLE
The members of an interface declaration or class should appear in a pre-defined order

### DIFF
--- a/src/main/java/com/technologyconversations/java8exercises/streams/Person.java
+++ b/src/main/java/com/technologyconversations/java8exercises/streams/Person.java
@@ -2,6 +2,10 @@ package com.technologyconversations.java8exercises.streams;
 
 public class Person {
 
+    private String name;
+    private int age;
+    private String nationality;
+
     public Person(final String nameValue, final int ageValue) {
         name = nameValue;
         age = ageValue;
@@ -13,18 +17,14 @@ public class Person {
         nationality = nationalityValue;
     }
 
-
-    private String name;
     public String getName() {
         return name;
     }
 
-    private int age;
     public int getAge() {
         return age;
     }
 
-    private String nationality;
     public String getNationality() {
         return nationality;
     }

--- a/src/main/java/com/technologyconversations/java8exercises/streams/Stats.java
+++ b/src/main/java/com/technologyconversations/java8exercises/streams/Stats.java
@@ -2,6 +2,11 @@ package com.technologyconversations.java8exercises.streams;
 
 public class Stats {
 
+    private long count;
+    private long sum;
+    private int min;
+    private int max;
+
     public Stats(final long countValue,
                  final long sumValue,
                  final int minValue,
@@ -12,22 +17,19 @@ public class Stats {
         max = maxValue;
     }
 
-    private long count;
+
     public final long getCount() {
         return count;
     }
 
-    private long sum;
     public final long getSum() {
         return sum;
     }
 
-    private int min;
     public final int getMin() {
         return min;
     }
 
-    private int max;
     public final int getMax() {
         return max;
     }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1213 - “The members of an interface declaration or class should appear in a pre-defined order”. 
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1213
Please let me know if you have any questions.
Ayman Abdelghany.
